### PR TITLE
Add six package

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,3 +4,4 @@ protobuf<4
 requests
 rstr
 xmltodict
+six


### PR DESCRIPTION
It appears that the "six" package is being used and may not be installed by default on most distros. This change is to add the six package to the requirements.